### PR TITLE
edit manage jenkins to manage paques ops

### DIFF
--- a/core/src/main/resources/hudson/model/ManageJenkinsAction/index.jelly
+++ b/core/src/main/resources/hudson/model/ManageJenkinsAction/index.jelly
@@ -27,14 +27,14 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout title="${%Manage Jenkins}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
+  <l:layout title="Manage Paques Ops" permissions="${app.MANAGE_AND_SYSTEM_READ}">
     <j:if test="${taskTags==null}">
       <st:include page="sidepanel.jelly" it="${app}" />
       <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
     </j:if>
 
     <l:main-panel>
-  <l:app-bar title="${%Manage Jenkins}">
+  <l:app-bar title="Manage Paques Ops">
         <l:search-bar placeholder="${%Search settings}" id="settings-search-bar" />
       </l:app-bar>
 

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsApiData/monitorsList.jelly
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsApiData/monitorsList.jelly
@@ -15,7 +15,7 @@
 
                 <p style="text-align: center; margin: 10px 0 0 0;">
                     <a href="${rootURL}/manage">
-                       ${%Manage Jenkins}
+                       Manage Paques Ops
                     </a>
                 </p>
             </j:when>


### PR DESCRIPTION
Resolve https://github.com/paquesid/products/issues/3839

Change :
- Change 'Manage Jenkins' to 'Manage Paques Ops'


https://isbid.sharepoint.com/:w:/s/ProductDevelopment/EfutadOJ_ixMnbDjweMe2-MBzHx5RgbJscdg9xWZsJ5LRA?e=aPMF8g